### PR TITLE
parse_type 0.6.2 (ursaverance effort)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# conda-build ... --channels https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
-channels:
-    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# conda-build ... --channels https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
+channels:
+    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -21,8 +20,8 @@ requirements:
     - wheel
   run:
     - python
-    - parse >=1.6
-    - six
+    - parse >=1.18.0
+    - six >=1.15
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ test:
 
 about:
   home: https://github.com/jenisys/parse_type
-  license: BSD-3-Clause
+  license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Simplifies to build parse types based on the parse module
-  license_family: BSD
   description: |
     parse_type extends the parse module (opposite of string.format()) with the following features:
       * build type converters for common use cases (enum/mapping, choice)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.0" %}
+{% set version = "0.6.2" %}
 
 package:
   name: parse_type
@@ -6,26 +6,31 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/parse_type/parse_type-{{ version }}.tar.gz
-  sha256: 20b43c660e48ed47f433bce5873a2a3d4b9b6a7ba47bd7f7d2a7cec4bec5551f
+  sha256: 79b1f2497060d0928bc46016793f1fca1057c4aacdf15ef876aa48d75a73a355
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  skip: true  # [py37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
     - pip
+    - wheel
   run:
-    - python >=3.6
+    - python
     - parse >=1.6
     - six
 
 test:
   imports:
     - parse_type
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/jenisys/parse_type
@@ -39,7 +44,8 @@ about:
       * build a type converter with a cardinality constraint (0..1, 0..*, 1..*) from the type converter with cardinality=1.
       * compose a type converter from other type converters
       * an extended parser that supports the CardinalityField naming schema and creates missing type variants (0..1, 0..*, 1..*) from the primary type converter
-    dev_url: https://github.com/jenisys/parse_type
+  dev_url: https://github.com/jenisys/parse_type
+  doc_url: https://github.com/jenisys/parse_type#parse_type
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-2696] parse_type 0.6.2

dev_url: https://github.com/jenisys/parse_type 
conda-forge: https://github.com/conda-forge/parse_type-feedstock
dependencies: https://github.com/jenisys/parse_type/blob/v0.6.2/setup.py

- linter
- update to version `0.6.2`, update sha
- remove `noarch`
- python script
- test commands `pip check`

**Dependency for** 
- AnacondaRecipes/behave-feedstock#2

**Depends on:** 
- AnacondaRecipes/parse-feedstock#2


[PKG-2696]: https://anaconda.atlassian.net/browse/PKG-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ